### PR TITLE
Update sashimi-plot.py

### DIFF
--- a/sashimi-plot.py
+++ b/sashimi-plot.py
@@ -579,7 +579,7 @@ if __name__ == "__main__":
                 a, junctions = read_bam(bam, args.coordinates, args.strand)
                 if a.keys() == ["+"] and all(map(lambda x: x==0, list(a.values()[0]))):
                         print("ERROR: No reads in the specified area.")
-                        exit(1)
+                        exit(0)
                 for strand in a:
                         # Store junction information
                         if args.junctions_bed:


### PR DESCRIPTION
This allow you to plot bam files that does not have reads in that specified region. Useful when you want to plot multi-group, multiple bam files and some of these file doesnot have reads in that specified region.